### PR TITLE
Use a multistage build to also build the application.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
+FROM gradle:jdk11 AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build
+
 FROM openjdk:11-jre-slim
-ADD build/libs/tuscan-0.0.1-SNAPSHOT.jar tuscan-docker.jar
+COPY --from=build /home/gradle/src/build/libs/tuscan-0.0.1-SNAPSHOT.jar tuscan-docker.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "tuscan-docker.jar"]


### PR DESCRIPTION
Instead of relying on the developer to build the application externally,
build the application in a multistage build and copy the jar file from the
builder image.